### PR TITLE
Allow Sane Break to ignore idle inhibitors if possible

### DIFF
--- a/src/linux/wayland/ext-idle-notify-v1.xml
+++ b/src/linux/wayland/ext-idle-notify-v1.xml
@@ -24,7 +24,7 @@
     DEALINGS IN THE SOFTWARE.
   </copyright>
 
-  <interface name="ext_idle_notifier_v1" version="1">
+  <interface name="ext_idle_notifier_v1" version="2">
     <description summary="idle notification manager">
       This interface allows clients to monitor user idle status.
 
@@ -54,9 +54,30 @@
       <arg name="timeout" type="uint" summary="minimum idle timeout in msec"/>
       <arg name="seat" type="object" interface="wl_seat"/>
     </request>
+
+    <!-- Version 2 additions -->
+
+    <request name="get_input_idle_notification" since="2">
+      <description summary="create a notification object">
+        Create a new idle notification object to track input from the
+        user, such as keyboard and mouse movement. Because this object is
+        meant to track user input alone, it ignores idle inhibitors.
+
+        The notification object has a minimum timeout duration and is tied to a
+        seat. The client will be notified if the seat is inactive for at least
+        the provided timeout. See ext_idle_notification_v1 for more details.
+
+        A zero timeout is valid and means the client wants to be notified as
+        soon as possible when the seat is inactive.
+      </description>
+      <arg name="id" type="new_id" interface="ext_idle_notification_v1"/>
+      <arg name="timeout" type="uint" summary="minimum idle timeout in msec"/>
+      <arg name="seat" type="object" interface="wl_seat"/>
+    </request>
+    
   </interface>
 
-  <interface name="ext_idle_notification_v1" version="1">
+  <interface name="ext_idle_notification_v1" version="2">
     <description summary="idle notification">
       This interface is used by the compositor to send idle notification events
       to clients.
@@ -65,9 +86,17 @@
       becomes idle when no user activity has happened for at least the timeout
       duration, starting from the creation of the notification object. User
       activity may include input events or a presence sensor, but is
-      compositor-specific. If an idle inhibitor is active (e.g. another client
-      has created a zwp_idle_inhibitor_v1 on a visible surface), the compositor
-      must not make the notification object idle.
+      compositor-specific.
+
+      How this notification responds to idle inhibitors depends on how
+      it was constructed. If constructed from the
+      get_idle_notification request, then if an idle inhibitor is
+      active (e.g. another client has created a zwp_idle_inhibitor_v1
+      on a visible surface), the compositor must not make the
+      notification object idle. However, if constructed from the
+      get_input_idle_notification request, then idle inhibitors are
+      ignored, and only input from the user, e.g. from a keyboard or
+      mouse, counts as activity.
 
       When the notification object becomes idle, an idled event is sent. When
       user activity starts again, the notification object stops being idle,

--- a/src/linux/wayland/idle.h
+++ b/src/linux/wayland/idle.h
@@ -47,6 +47,12 @@ class IdleTimeWayland : public SystemIdleTime {
   wl_seat *seat;
   ext_idle_notifier_v1 *idleNotifier = nullptr;
   ext_idle_notification_v1 *idleNotification = nullptr;
+
+  struct ext_idle_notification_v1 *
+  (*get_idle_notification)(struct ext_idle_notifier_v1 *ext_idle_notifier_v1,
+			   uint32_t timeout,
+			   struct wl_seat *seat);
+  
   bool isWatching = false;
 };
 


### PR DESCRIPTION
This is analogous to a [similar fix for Workrave](https://github.com/rcaelers/workrave/pull/596) and works pretty much the same way. It uses [version 2 of the ext-idle-notify protocol](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/commit/20bcf732a9a173ae7d437882159fb7ababb4713e) where possible. If version 2 is unavailable, Sane Break will fallback to using the older version of the protocol that does not ignore idle inhibitors. This should address issues discussed in https://github.com/AllanChain/sane-break/issues/22.

The catch is that until Wayland compositors catch up and incorporate the latest version of the ext-idle-notify protocol, this pull request will have somewhat limited usefulness. However, it is backward-compatible with current Wayland compositors.

For those using Arch Linux, there are a couple PKGBUILD files that you can use to test this pull request:

* [PKGBUILD-wlroots-git.txt](https://github.com/user-attachments/files/18552149/PKGBUILD-wlroots-git.txt) This PKGBUILD points to my fork of wlroots with an implementation of version 2 of ext-idle-notify protocol. It should be built against the [wayland-protocols-git AUR package](https://aur.archlinux.org/packages/wayland-protocols-git).

* [PKGBUILD-sane-break-new.txt](https://github.com/user-attachments/files/18552150/PKGBUILD-sane-break-new.txt) This PKGBUILD points to a fork incorporating the changes specified in this pull request.

Once packages built from those PKGBUILD files are installed, you can install a Wayland compositor from the AUR that makes use of the wlroots-git package. I myself have used sway-git for testing.
