### PR TITLE
fix: place GNOME break overlay on each monitor in multi-monitor setups

### DIFF
--- a/packaging/linux/gnome/sane-break@allanchain.github.io/extension.js
+++ b/packaging/linux/gnome/sane-break@allanchain.github.io/extension.js
@@ -98,7 +98,8 @@ export default class SaneBreakGNOME extends Extension {
 
   _applyWindowWorkaround(window) {
     // GNOME does not expose layer-shell here, so the shell extension forcefully
-    // stretches the transparent Wayland workaround window to cover the monitor.
+    // stretches the transparent Wayland workaround window to cover the full
+    // virtual desktop.
     const [w, h] = global.display.get_size();
     window.stick();
     window.move_resize_frame(false, 0, 0, w, h);

--- a/src/app/break-window.cpp
+++ b/src/app/break-window.cpp
@@ -217,7 +217,7 @@ void BreakWindow::showFullScreen() {
   QPropertyAnimation* resizeAnim =
       new QPropertyAnimation(m_waylandWorkaround ? mainWidget : this, "geometry");
   resizeAnim->setStartValue(m_waylandWorkaround ? mainWidget->geometry() : geometry());
-  resizeAnim->setEndValue(m_waylandWorkaround ? screen()->availableGeometry()
+  resizeAnim->setEndValue(m_waylandWorkaround ? m_intendedScreenGeometry
                                               : screen()->geometry());
   resizeAnim->setDuration(300);
   resizeAnim->start();
@@ -263,10 +263,15 @@ void BreakWindow::showFlashPrompt() {
 
   QPropertyAnimation* resizeAnim =
       new QPropertyAnimation(m_waylandWorkaround ? mainWidget : this, "geometry");
-  QRect rect =
-      m_waylandWorkaround ? screen()->availableGeometry() : screen()->geometry();
-  QRect targetGeometry = QRect(rect.x() + rect.width() / 2 - SMALL_WINDOW_WIDTH / 2,
-                               rect.y(), SMALL_WINDOW_WIDTH, SMALL_WINDOW_HEIGHT);
+  QRect rect = screen()->geometry();
+  QRect targetGeometry = m_waylandWorkaround
+                             ? QRect(m_intendedScreenGeometry.x() +
+                                         m_intendedScreenGeometry.width() / 2 -
+                                         SMALL_WINDOW_WIDTH / 2,
+                                     m_intendedScreenGeometry.y(),
+                                     SMALL_WINDOW_WIDTH, SMALL_WINDOW_HEIGHT)
+                             : QRect(rect.x() + rect.width() / 2 - SMALL_WINDOW_WIDTH / 2,
+                                     rect.y(), SMALL_WINDOW_WIDTH, SMALL_WINDOW_HEIGHT);
   resizeAnim->setStartValue(m_waylandWorkaround ? mainWidget->geometry() : geometry());
   resizeAnim->setEndValue(targetGeometry);
   resizeAnim->setDuration(100);
@@ -274,15 +279,19 @@ void BreakWindow::showFlashPrompt() {
 }
 
 void BreakWindow::initSize(QScreen* screen) {
+  m_intendedScreenGeometry = screen->geometry();
   if (m_waylandWorkaround) {
-    QRect rect = screen->availableGeometry();
+    QRect rect = m_intendedScreenGeometry;
     // Avoid using full height when initializing the main window. GNOME will refuse to
     // make the window always on top (done in custom shell extension) if it is too large
     // See https://askubuntu.com/questions/1122921.
     rect.setHeight(100);
     setGeometry(rect);
-    mainWidget->setGeometry(rect.x() + rect.width() / 2 - SMALL_WINDOW_WIDTH / 2,
-                            rect.y(), SMALL_WINDOW_WIDTH, SMALL_WINDOW_HEIGHT);
+    mainWidget->setGeometry(m_intendedScreenGeometry.x() +
+                              m_intendedScreenGeometry.width() / 2 -
+                              SMALL_WINDOW_WIDTH / 2,
+                          m_intendedScreenGeometry.y(),
+                          SMALL_WINDOW_WIDTH, SMALL_WINDOW_HEIGHT);
   } else {
     QRect rect = screen->geometry();
     setGeometry(rect.x() + rect.width() / 2 - SMALL_WINDOW_WIDTH / 2, rect.y(),
@@ -298,7 +307,7 @@ void BreakWindow::initSize(QScreen* screen) {
     QString path = url.isLocalFile() ? url.toLocalFile() : m_data.theme.backgroundImage;
     QPixmap original(path);
     if (!original.isNull()) {
-      QSize targetSize = m_waylandWorkaround ? screen->availableGeometry().size()
+      QSize targetSize = m_waylandWorkaround ? m_intendedScreenGeometry.size()
                                              : screen->geometry().size();
       QPixmap scaled = original.scaled(targetSize, Qt::KeepAspectRatioByExpanding,
                                        Qt::SmoothTransformation);

--- a/src/app/break-window.h
+++ b/src/app/break-window.h
@@ -60,6 +60,7 @@ class BreakWindow : public QMainWindow {
   QGraphicsOpacityEffect* m_bgImageOpacity = nullptr;
   bool m_waylandWorkaround = false;
   bool m_supportTransparentInput = true;
+  QRect m_intendedScreenGeometry;
   int m_totalSeconds;
 
   static void colorizeButton(QPushButton* button, QColor color);


### PR DESCRIPTION
## Problem
On GNOME/Wayland with multiple monitors, the break overlay is sized to the whole virtual desktop and placed on the wrong monitor, so it appears cut off or offset on non-primary displays.

## Root cause
Two coordinate mismatches:
1. The Qt break window uses global screen coordinates for the `mainWidget` child widget inside the Wayland workaround window, but the parent window is later moved/resized by the GNOME extension to a single monitor.
2. The GNOME extension resizes each break window to `global.display.get_size()` (the whole desktop) instead of the target monitor's geometry.
3. On Wayland, `MetaWindow.move_to_monitor()` is asynchronous. The extension was calling `move_to_monitor()` and then immediately `move_resize_frame()`, so the resize happened before the window actually entered the target monitor, causing the overlay to be sized/positioned for the wrong display.

## Fix
- `src/app/break-window.cpp`: in the `m_waylandWorkaround` branches, use coordinates relative to the parent window frame for `mainWidget` geometry.
- `packaging/linux/gnome/sane-break@allanchain.github.io/extension.js`: detect which monitor each break window was created on; if it is already on that monitor, resize immediately; otherwise call `move_to_monitor()` and wait for the `window-entered-monitor` signal before resizing. A 750 ms fallback timeout ensures the resize still happens if the signal is never emitted.

## Notes
- This intentionally touches only the Wayland workaround path; layer-shell and X11 paths are unchanged.
- Tested on a three-monitor setup (vertical left, center primary, laptop right).
